### PR TITLE
add subject to Email.transform_data

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ email = Mailinator::Email.get('email-abcd1234')
 Now you have access to some methods:
 
 * `email.id`
+* `email.subject`
 * `email.body`
 * `email.body_html`
 * `email.read?`

--- a/lib/mailinator/models/email.rb
+++ b/lib/mailinator/models/email.rb
@@ -6,6 +6,7 @@ module Mailinator
       def transform_data
         {
           id: @data['data']['id'],
+          subject: @data['data']['subject'],
           body: @data['data']['parts'].first['body'],
           body_html: retrieve_body_html,
           inbox_fetches_left: @data['apiInboxFetchesLeft'],

--- a/spec/lib/mailinator/email_spec.rb
+++ b/spec/lib/mailinator/email_spec.rb
@@ -11,6 +11,7 @@ describe Mailinator::Email do
     body = 'This is a body'
     message = Mailinator::Email.get('abcd1234')
     expect(message.id).to eq('1419696967-44152505-recipient')
+    expect(message.subject).to eq('This is a subject')
     expect(message.body).to eq(body)
     expect(message.body_html).to include("<p>#{body}</p>")
     expect(message.read?).to_not be


### PR DESCRIPTION
Add subject in the Email.transform_data to be able to return the subject value for the email.
